### PR TITLE
*だと同ディレクトリにあるファイルを変数で渡してしまうため、xへ変更

### DIFF
--- a/deno-projects/reverse-polish-notation/main.spec.ts
+++ b/deno-projects/reverse-polish-notation/main.spec.ts
@@ -38,13 +38,13 @@ Deno.test("Subtraction", () => {
 });
 
 Deno.test("Multiplication", () => {
-  const result : number | undefined = reversePolishNotation(["1", "5", "*"]);
+  const result : number | undefined = reversePolishNotation(["1", "5", "x"]);
   assertEquals(result, 5);
 
-  const result2 : number | undefined = reversePolishNotation(["1", "*", "2"]);
+  const result2 : number | undefined = reversePolishNotation(["1", "x", "2"]);
   assertEquals(result2, undefined);
 
-  const result3 : number | undefined = reversePolishNotation(["*", "1", "1"]);
+  const result3 : number | undefined = reversePolishNotation(["x", "1", "1"]);
   assertEquals(result3, undefined);
 });
 

--- a/deno-projects/reverse-polish-notation/main.ts
+++ b/deno-projects/reverse-polish-notation/main.ts
@@ -29,7 +29,7 @@ function reversePolishNotation(input: string[]): number | undefined {
           }
           break;
         }
-        case "*": {
+        case "x": {
           const number1: number | undefined = stack.pop();
           const number2: number | undefined = stack.pop();
           if (typeof number1 === "number" && typeof number2 === "number") {


### PR DESCRIPTION
## 実装したこと

`*` を変数として渡すと、同ディレクトリにあるファイル名の文字列がDeno.argsへ渡ってしまう問題を修正した
![スクリーンショット 2023-07-30 12 34 36](https://github.com/sontixyou/TS-beginner/assets/19817196/a5edd049-4ee7-498c-8a47-1242c5890321)


## 備考
